### PR TITLE
add docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+# Include any files or directories that you don't want to be copied to your
+# container here (e.g., local build artifacts, temporary files, etc.).
+#
+# For more help, visit the .dockerignore file reference guide at
+# https://docs.docker.com/go/build-context-dockerignore/
+
+**/.classpath
+**/.dockerignore
+**/.env
+**/.git
+**/.gitignore
+**/.project
+**/.settings
+**/.toolstarget
+**/.vs
+**/.vscode
+**/.next
+**/.cache
+**/*.*proj.user
+**/*.dbmdl
+**/*.jfm
+**/charts
+**/docker-compose*
+**/compose*
+**/Dockerfile*
+**/node_modules
+**/npm-debug.log
+**/obj
+**/secrets.dev.yaml
+**/values.dev.yaml
+**/build
+**/dist
+LICENSE
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+# use the official Bun image
+# see all versions at https://hub.docker.com/r/oven/bun/tags
+FROM oven/bun:1 as base
+
+# development
+COPY package.json bun.lockb ./
+RUN bun install
+COPY . .
+EXPOSE 3000/tcp
+ENTRYPOINT [ "bun", "run", "dev" ]
+
+# install dependencies into temp directory
+# this will cache them and speed up future builds
+# FROM base AS install
+# RUN mkdir -p /temp/dev
+# COPY package.json bun.lockb /temp/dev/
+# RUN cd /temp/dev && bun install --frozen-lockfile
+
+# install with --production (exclude devDependencies)
+# RUN mkdir -p /temp/prod
+# COPY package.json bun.lockb /temp/prod/
+# RUN cd /temp/prod && bun install --frozen-lockfile --production
+
+# copy node_modules from temp directory
+# then copy all (non-ignored) project files into the image
+# FROM base AS prerelease
+# COPY --from=install /temp/dev/node_modules node_modules
+# COPY . .
+
+# [optional] tests & build
+# ENV NODE_ENV=production
+# RUN bun test
+# RUN bun run build
+
+# copy production dependencies and source code into final image
+# FROM base AS release
+# COPY --from=install /temp/prod/node_modules node_modules
+# COPY --from=prerelease /usr/src/app/index.ts .
+# COPY --from=prerelease /usr/src/app/package.json .

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # see all versions at https://hub.docker.com/r/oven/bun/tags
 FROM oven/bun:1 as base
 
-# development
+FROM base as dev
 COPY package.json bun.lockb ./
 RUN bun install
 COPY . .

--- a/README.Docker.md
+++ b/README.Docker.md
@@ -1,0 +1,42 @@
+### Development
+
+Use `docker compose watch` to run the application containers in watch mode during development.
+
+Use `docker compose up -d` to run in detached mode, ie: not in the current terminal.
+
+Using `volumes` lets you persist data even when the container is trashed and restarted.
+
+Use bind mount to access local folders for hot reload during development:
+
+```
+app:
+    # ...
+    volumes:
+      - ./app:/usr/src/app
+      - /usr/src/app/node_modules
+```
+
+The volumes element tells Compose to mount the local folder ./app to /usr/src/app in the container for the todo-app service. This particular bind mount overwrites the static contents of the /usr/src/app directory in the container and creates what is known as a development container. The second instruction, /usr/src/app/node_modules, prevents the bind mount from overwriting the container's node_modules directory to preserve the packages installed in the container.
+
+### Building and running your application
+
+When you're ready, start your application by running:
+`docker compose up --build`.
+
+Your application will be available at http://localhost:3000.
+
+### Deploying your application to the cloud
+
+First, build your image, e.g.: `docker build -t myapp .`.
+If your cloud uses a different CPU architecture than your development
+machine (e.g., you are on a Mac M1 and your cloud provider is amd64),
+you'll want to build the image for that platform, e.g.:
+`docker build --platform=linux/amd64 -t myapp .`.
+
+Then, push it to your registry, e.g. `docker push myregistry.com/myapp`.
+
+Consult Docker's [getting started](https://docs.docker.com/go/get-started-sharing/)
+docs for more detail on building and pushing.
+
+### References
+* [Docker's Node.js guide](https://docs.docker.com/language/nodejs/)

--- a/app/index.ts
+++ b/app/index.ts
@@ -3,7 +3,7 @@ import { Hono } from 'hono'
 const app = new Hono()
 
 app.get('/', (c) => {
-    return c.text('Hello Hono!')
+    return c.text('Hello world!')
 })
 
 export default app

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,63 @@
+# Comments are provided throughout this file to help you get started.
+# If you need more help, visit the Docker Compose reference guide at
+# https://docs.docker.com/go/compose-spec-reference/
+
+# Here the instructions define your application as a service called "server".
+# This service is built from the Dockerfile in the current directory.
+# You can add other services your application may depend on here, such as a
+# database or a cache. For examples, see the Awesome Compose repository:
+# https://github.com/docker/awesome-compose
+
+name: lemonaid
+
+services:
+  app:
+    build:
+      context: .
+    ports:
+      - 3000:3000
+    volumes:
+      - app:/data/app
+    develop:
+      watch:
+        - path: ./app
+          action: rebuild
+          target: /var/www
+        - path: ./infrastructure
+          action: rebuild
+
+volumes:
+  app:
+
+# The commented out section below is an example of how to define a PostgreSQL
+# database that your application can use. `depends_on` tells Docker Compose to
+# start the database before your application. The `db-data` volume persists the
+# database data between container restarts. The `db-password` secret is used
+# to set the database password. You must create `db/password.txt` and add
+# a password of your choosing to it before running `docker-compose up`.
+#     depends_on:
+#       db:
+#         condition: service_healthy
+#   db:
+#     image: postgres
+#     restart: always
+#     user: postgres
+#     secrets:
+#       - db-password
+#     volumes:
+#       - db-data:/var/lib/postgresql/data
+#     environment:
+#       - POSTGRES_DB=example
+#       - POSTGRES_PASSWORD_FILE=/run/secrets/db-password
+#     expose:
+#       - 5432
+#     healthcheck:
+#       test: [ "CMD", "pg_isready" ]
+#       interval: 10s
+#       timeout: 5s
+#       retries: 5
+# volumes:
+#   db-data:
+# secrets:
+#   db-password:
+#     file: db/password.txt

--- a/package.json
+++ b/package.json
@@ -12,8 +12,11 @@
         "url": "https://github.com/the-rainbow-bridge/lemonaid"
     },
     "scripts": {
-        "dev": "bun run --hot src/index.ts",
-        "format": "prettier --write ."
+        "dev": "bun run --hot app/index.ts",
+        "format": "prettier --write .",
+        "start": "bun run app/index.ts",
+        "docker:build": "docker build -t lemonaid .",
+        "docker:dev": "docker compose watch"
     },
     "dependencies": {
         "@ediri/vultr": "^2.19.0",


### PR DESCRIPTION
Adds a development Docker image, a compose file and `docker compose watch` to run the application containers in watch mode during development, corresponding `.dockerignore`.

Adds scripts, self documenting.